### PR TITLE
Use the default `serde` naming convention instead of camel case.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -14,7 +14,6 @@ pub(crate) type Commands = BTreeMap<LogIndex, Command>;
 
 /// Commmand that can be proposed to [`Server`][crate::Server].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub enum Command {
     /// A command proposed via [`Request::CreateCluster`] API.

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -61,7 +61,6 @@ pub(crate) struct Member {
 
 /// Replicated state machine responsible for handling system commands.
 #[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SystemMachine {
     pub(crate) min_election_timeout_ms: u32,
     pub(crate) max_election_timeout_ms: u32,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -259,7 +259,6 @@ impl LogEntries {
 ///
 /// See also: [`raftbare::Message::AppendEntriesCall`]
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct AppendEntriesCallParams {
     pub header: MessageHeader,
@@ -294,7 +293,6 @@ impl AppendEntriesCallParams {
 ///
 /// See also: [`raftbare::Message::AppendEntriesReply`]
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct AppendEntriesReplyParams {
     pub header: MessageHeader,
@@ -324,7 +322,6 @@ impl AppendEntriesReplyParams {
 ///
 /// See also: [`raftbare::Message::RequestVoteCall`]
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct RequestVoteCallParams {
     pub header: MessageHeader,
@@ -344,7 +341,6 @@ impl RequestVoteCallParams {
 ///
 /// See also: [`raftbare::Message::RequestVoteReply`]
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct RequestVoteReplyParams {
     pub header: MessageHeader,
@@ -364,7 +360,6 @@ impl RequestVoteReplyParams {
 ///
 /// See also: [`raftbare::Action::InstallSnapshot`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct InstallSnapshotParams {
     // [NOTE] Unlike the other fields, this information is specific to a node.
@@ -378,7 +373,6 @@ pub struct InstallSnapshotParams {
 
 /// Parameters of [`Request::CreateCluster`].
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateClusterParams {
     /// Minimum value for the Raft election timeout (default: `100` milliseconds).
     ///
@@ -450,7 +444,6 @@ pub struct ApplyParams {
 
 /// Successful result of [`Request::TakeSnapshot`].
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TakeSnapshotResult {
     /// Log index where the snapshot was taken.
     pub snapshot_index: LogIndex,
@@ -458,7 +451,6 @@ pub struct TakeSnapshotResult {
 
 /// Successful result of [`Request::GetServerState`].
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct GetServerStateResult<'a, M> {
     pub addr: SocketAddr,
@@ -517,7 +509,6 @@ pub struct ReplyErrorParams {
 
 /// Caller of an RPC request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct Caller {
     pub node_id: NodeId,


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes focused on removing the `#[serde(rename_all = "camelCase")]` attribute from various structs across different files. These changes are aimed at standardizing the serialization format.

### Removal of `#[serde(rename_all = "camelCase")]` attribute:

* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL17): Removed `#[serde(rename_all = "camelCase")]` from the `Command` enum.
* [`src/machines.rs`](diffhunk://#diff-ba0f7ff77399be0a27845ee322c1cd53d6df57f235e6ea90268c36249f88c66bL64): Removed `#[serde(rename_all = "camelCase")]` from the `SystemMachine` struct.
* [`src/messages.rs`](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL262): Removed `#[serde(rename_all = "camelCase")]` from multiple structs, including `AppendEntriesCallParams`, `AppendEntriesReplyParams`, `RequestVoteCallParams`, `RequestVoteReplyParams`, `InstallSnapshotParams`, `CreateClusterParams`, `TakeSnapshotResult`, `GetServerStateResult`, and `Caller`. [[1]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL262) [[2]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL297) [[3]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL327) [[4]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL347) [[5]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL367) [[6]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL381) [[7]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL453-L461) [[8]](diffhunk://#diff-121f57fd9da9016a85108d2a879fdc4e8d03e3699857e7528d90f2199229153fL520)