### PR TITLE
Add `List` input to the kvs example

### DIFF
--- a/examples/kvs.rs
+++ b/examples/kvs.rs
@@ -56,6 +56,9 @@ impl Machine for KvsMachine {
                 let value = self.entries.remove(&key);
                 ctx.output(&value);
             }
+            KvsInput::List => {
+                ctx.output(&self.entries.keys().collect::<Vec<_>>());
+            }
         }
     }
 }
@@ -72,4 +75,5 @@ enum KvsInput {
     Delete {
         key: String,
     },
+    List,
 }


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces a new feature to the `KvsMachine` implementation in `examples/kvs.rs`. The changes add support for listing all keys stored in the key-value store.

Key feature addition:

* [`examples/kvs.rs`](diffhunk://#diff-59a516acb31cce1420ed19959d7c3a12addd51aaaa61262ed6efdac5e3d12a20R78): Added a new `KvsInput::List` variant to the `KvsInput` enum to handle the listing of all keys.
* [`examples/kvs.rs`](diffhunk://#diff-59a516acb31cce1420ed19959d7c3a12addd51aaaa61262ed6efdac5e3d12a20R59-R61): Implemented the handling of the `KvsInput::List` variant in the `impl Machine for KvsMachine` block to output the list of keys.